### PR TITLE
CDDSO-392 Add alternative license

### DIFF
--- a/tables/GCModelDev_CV.json
+++ b/tables/GCModelDev_CV.json
@@ -334,7 +334,7 @@
         ],
         "license":[
             "^GCModelDev model data is licensed under the Open Government License v3 (https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/)$",
-            "^Model development data is not licenced for use outside of the organisation that generated it. Please contact the owner of the model simulation if you wish to use it beyond the source organisation."
+            "^Model development data is not licenced for use outside of the organisation that generated it. Please contact the owner of the model simulation if you wish to use it beyond the source organisation.$"
         ],
         "mip_era":[
             "GCModelDev"


### PR DESCRIPTION
Request from Emma Hogan to add an alternative license:
`Model development data is not licenced for use outside of the organisation that generated it. Please contact the owner of the model simulation if you wish to use it beyond the source organisation.`  