### PR TITLE
CDDSO 486 add long names to GCAERmon variables

### DIFF
--- a/tables/GCModelDev_3hr.json
+++ b/tables/GCModelDev_3hr.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table 3hr", 
         "realm": "atmos", 

--- a/tables/GCModelDev_6hrLev.json
+++ b/tables/GCModelDev_6hrLev.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table 6hrLev", 
         "realm": "atmos", 

--- a/tables/GCModelDev_6hrPlev.json
+++ b/tables/GCModelDev_6hrPlev.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table 6hrPlev", 
         "realm": "atmos", 

--- a/tables/GCModelDev_6hrPlevPt.json
+++ b/tables/GCModelDev_6hrPlevPt.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table 6hrPlevPt", 
         "realm": "atmos", 

--- a/tables/GCModelDev_AERday.json
+++ b/tables/GCModelDev_AERday.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table AERday", 
         "realm": "aerosol", 

--- a/tables/GCModelDev_AERhr.json
+++ b/tables/GCModelDev_AERhr.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table AERhr", 
         "realm": "aerosol", 

--- a/tables/GCModelDev_AERmon.json
+++ b/tables/GCModelDev_AERmon.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table AERmon", 
         "realm": "aerosol", 

--- a/tables/GCModelDev_AERmonZ.json
+++ b/tables/GCModelDev_AERmonZ.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table AERmonZ", 
         "realm": "aerosol", 

--- a/tables/GCModelDev_Amon.json
+++ b/tables/GCModelDev_Amon.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table Amon", 
         "realm": "atmos atmosChem", 

--- a/tables/GCModelDev_CF3hr.json
+++ b/tables/GCModelDev_CF3hr.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table CF3hr", 
         "realm": "atmos", 

--- a/tables/GCModelDev_CFday.json
+++ b/tables/GCModelDev_CFday.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table CFday", 
         "realm": "atmos", 

--- a/tables/GCModelDev_CFmon.json
+++ b/tables/GCModelDev_CFmon.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table CFmon", 
         "realm": "atmos", 

--- a/tables/GCModelDev_CFsubhr.json
+++ b/tables/GCModelDev_CFsubhr.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table CFsubhr", 
         "realm": "atmos", 

--- a/tables/GCModelDev_CV.json
+++ b/tables/GCModelDev_CV.json
@@ -30,7 +30,7 @@
             "variant_label"
         ],
         "version_metadata":{
-            "CV_collection_version":"GCModelDev v0.0.22"
+            "CV_collection_version":"GCModelDev v0.0.23"
         },
         "activity_id":{
             "DECK":"CMIP DECK Experiments",

--- a/tables/GCModelDev_E1hr.json
+++ b/tables/GCModelDev_E1hr.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table E1hr", 
         "realm": "atmos", 

--- a/tables/GCModelDev_E1hrClimMon.json
+++ b/tables/GCModelDev_E1hrClimMon.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table E1hrClimMon", 
         "realm": "atmos", 

--- a/tables/GCModelDev_E3hr.json
+++ b/tables/GCModelDev_E3hr.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table E3hr", 
         "realm": "land", 

--- a/tables/GCModelDev_E3hrPt.json
+++ b/tables/GCModelDev_E3hrPt.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table E3hrPt", 
         "realm": "atmos", 

--- a/tables/GCModelDev_E6hrZ.json
+++ b/tables/GCModelDev_E6hrZ.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table E6hrZ", 
         "realm": "atmos", 

--- a/tables/GCModelDev_Eday.json
+++ b/tables/GCModelDev_Eday.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table Eday", 
         "realm": "land", 

--- a/tables/GCModelDev_EdayZ.json
+++ b/tables/GCModelDev_EdayZ.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table EdayZ", 
         "realm": "atmos", 

--- a/tables/GCModelDev_Efx.json
+++ b/tables/GCModelDev_Efx.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table Efx", 
         "realm": "land", 

--- a/tables/GCModelDev_Emon.json
+++ b/tables/GCModelDev_Emon.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table Emon", 
         "realm": "land", 

--- a/tables/GCModelDev_EmonZ.json
+++ b/tables/GCModelDev_EmonZ.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table EmonZ", 
         "realm": "atmos", 

--- a/tables/GCModelDev_Esubhr.json
+++ b/tables/GCModelDev_Esubhr.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table Esubhr", 
         "realm": "atmos", 

--- a/tables/GCModelDev_Eyr.json
+++ b/tables/GCModelDev_Eyr.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table Eyr", 
         "realm": "land", 

--- a/tables/GCModelDev_GC1hr.json
+++ b/tables/GCModelDev_GC1hr.json
@@ -1,6 +1,6 @@
 {
     "Header":{
-        "data_specs_version":"GCModelDev v0.0.22",
+        "data_specs_version":"GCModelDev v0.0.23",
         "cmor_version":"3.5",
         "table_id":"Table GC1hr",
         "realm":"atmos",

--- a/tables/GCModelDev_GC1hrPt.json
+++ b/tables/GCModelDev_GC1hrPt.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table GC1hrPt", 
         "realm": "atmos", 

--- a/tables/GCModelDev_GC3hr.json
+++ b/tables/GCModelDev_GC3hr.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table GC3hr", 
         "realm": "atmos", 

--- a/tables/GCModelDev_GC3hrPtUV.json
+++ b/tables/GCModelDev_GC3hrPtUV.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table GC3hrPtUV", 
         "realm": "atmos", 

--- a/tables/GCModelDev_GCAERmon.json
+++ b/tables/GCModelDev_GCAERmon.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22",
+        "data_specs_version": "GCModelDev v0.0.23",
         "cmor_version": "3.5",
         "table_id": "Table GCAERmon",
         "realm": "atmos atmosChem",

--- a/tables/GCModelDev_GCAmon.json
+++ b/tables/GCModelDev_GCAmon.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22",
+        "data_specs_version": "GCModelDev v0.0.23",
         "cmor_version": "3.5",
         "table_id": "Table GCAmon",
         "realm": "atmos atmosChem",

--- a/tables/GCModelDev_GCAmon6hr.json
+++ b/tables/GCModelDev_GCAmon6hr.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22",
+        "data_specs_version": "GCModelDev v0.0.23",
         "cmor_version": "3.5",
         "table_id": "Table GCAmon6hr",
         "realm": "atmos atmosChem",

--- a/tables/GCModelDev_GCAmon6hrUV.json
+++ b/tables/GCModelDev_GCAmon6hrUV.json
@@ -1,6 +1,6 @@
 {
     "Header":{
-        "data_specs_version":"GCModelDev v0.0.22",
+        "data_specs_version":"GCModelDev v0.0.23",
         "cmor_version":"3.5",
         "table_id":"Table GCAmon6hrUV",
         "realm":"atmos atmosChem",

--- a/tables/GCModelDev_GCAmonUV.json
+++ b/tables/GCModelDev_GCAmonUV.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table GCAmonUV", 
         "realm": "atmos atmosChem", 

--- a/tables/GCModelDev_GCLmon.json
+++ b/tables/GCModelDev_GCLmon.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22",
+        "data_specs_version": "GCModelDev v0.0.23",
         "cmor_version": "3.5",
         "table_id": "Table GCLmon",
         "realm": "land",

--- a/tables/GCModelDev_GCOyr.json
+++ b/tables/GCModelDev_GCOyr.json
@@ -1,6 +1,6 @@
 {
     "Header":{
-        "data_specs_version":"GCModelDev v0.0.22",
+        "data_specs_version":"GCModelDev v0.0.23",
         "cmor_version":"3.5",
         "table_id":"Table GCOyr",
         "realm":"ocnBgchem",

--- a/tables/GCModelDev_GCday.json
+++ b/tables/GCModelDev_GCday.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22",
+        "data_specs_version": "GCModelDev v0.0.23",
         "cmor_version": "3.5",
         "table_id": "Table GCday",
         "realm": "atmos atmosChem",

--- a/tables/GCModelDev_IfxAnt.json
+++ b/tables/GCModelDev_IfxAnt.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table IfxAnt", 
         "realm": "landIce", 

--- a/tables/GCModelDev_IfxGre.json
+++ b/tables/GCModelDev_IfxGre.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table IfxGre", 
         "realm": "landIce", 

--- a/tables/GCModelDev_ImonAnt.json
+++ b/tables/GCModelDev_ImonAnt.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table ImonAnt", 
         "realm": "landIce land", 

--- a/tables/GCModelDev_ImonGre.json
+++ b/tables/GCModelDev_ImonGre.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table ImonGre", 
         "realm": "landIce land", 

--- a/tables/GCModelDev_IyrAnt.json
+++ b/tables/GCModelDev_IyrAnt.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table IyrAnt", 
         "realm": "landIce", 

--- a/tables/GCModelDev_IyrGre.json
+++ b/tables/GCModelDev_IyrGre.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table IyrGre", 
         "realm": "landIce", 

--- a/tables/GCModelDev_LImon.json
+++ b/tables/GCModelDev_LImon.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table LImon", 
         "realm": "landIce land", 

--- a/tables/GCModelDev_Lmon.json
+++ b/tables/GCModelDev_Lmon.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table Lmon", 
         "realm": "land", 

--- a/tables/GCModelDev_Oclim.json
+++ b/tables/GCModelDev_Oclim.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table Oclim", 
         "realm": "ocean", 

--- a/tables/GCModelDev_Oday.json
+++ b/tables/GCModelDev_Oday.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table Oday", 
         "realm": "ocnBgchem", 

--- a/tables/GCModelDev_Odec.json
+++ b/tables/GCModelDev_Odec.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table Odec", 
         "realm": "ocean", 

--- a/tables/GCModelDev_Ofx.json
+++ b/tables/GCModelDev_Ofx.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table Ofx", 
         "realm": "ocean", 

--- a/tables/GCModelDev_Omon.json
+++ b/tables/GCModelDev_Omon.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table Omon", 
         "realm": "ocnBgchem", 

--- a/tables/GCModelDev_Oyr.json
+++ b/tables/GCModelDev_Oyr.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table Oyr", 
         "realm": "ocnBgchem", 

--- a/tables/GCModelDev_SIday.json
+++ b/tables/GCModelDev_SIday.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table SIday", 
         "realm": "seaIce", 

--- a/tables/GCModelDev_SImon.json
+++ b/tables/GCModelDev_SImon.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table SImon", 
         "realm": "seaIce", 

--- a/tables/GCModelDev_day.json
+++ b/tables/GCModelDev_day.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table day", 
         "realm": "atmos", 

--- a/tables/GCModelDev_fx.json
+++ b/tables/GCModelDev_fx.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "cmor_version": "3.5", 
         "table_id": "Table fx", 
         "realm": "land", 

--- a/tables/GCModelDev_grids.json
+++ b/tables/GCModelDev_grids.json
@@ -1,6 +1,6 @@
 {
     "Header": {
-        "data_specs_version": "GCModelDev v0.0.22", 
+        "data_specs_version": "GCModelDev v0.0.23", 
         "table_id": "Table grids", 
         "cmor_version": "3.5", 
         "table_date": "28 May 2020", 


### PR DESCRIPTION
in v0.0.22 there were no long_names for variable sin the GCAERmon table, but this causes issues with CDDS QC and is an anomaly compared to the rest of the CMIP based variables.

I've inserted long names based on the standard names (replacing underscores with spaces) and have upped the version number.